### PR TITLE
Remove reference to missing image

### DIFF
--- a/app/en/mini-enaep.js
+++ b/app/en/mini-enaep.js
@@ -555,9 +555,6 @@ import { waitForElement } from './util.js';
               text: function() {
                 return $scope.currentItem.blockTitle;
               }
-            },
-            completionIcon: {
-              visible: returnFalse
             }
           },
           timer: {

--- a/app/en/scripts/toolbarTemplate.html
+++ b/app/en/scripts/toolbarTemplate.html
@@ -230,7 +230,6 @@
             </span>
             <span class="sceneId" ng-show="settings.display.readingSceneId.visible()">{{ getItemTitle() }}</span>
             <span class="blockTitle" ng-show="settings.display.blockTitle.visible()">{{ settings.display.blockTitle.text() }}</span>
-            <img id="iconCompleted" ng-show="settings.display.completionIcon.visible()" src="/content/images/student/flagCompleted.png" />
         </div>
         <div class="toolbar-button-group">
             <button id="timer-btn" class="toolbar-button btn-sticky btn-tray-master" button-name="timer" tabindex="0"

--- a/app/es/mini-enaep.js
+++ b/app/es/mini-enaep.js
@@ -362,9 +362,6 @@ import toolbarConfigs from './toolbar-configs.js';
 							visible: returnTrue,
 							text: function () { return $scope.currentItem.blockTitle; }
 						},
-						completionIcon: {
-							visible: returnFalse
-						}
 					},
 					timer: {
 						visible: returnTrue,

--- a/app/es/scripts/toolbarTemplate.html
+++ b/app/es/scripts/toolbarTemplate.html
@@ -230,7 +230,6 @@
             </span>
             <span class="sceneId" ng-show="settings.display.readingSceneId.visible()">{{ getItemTitle() }}</span>
             <span class="blockTitle" ng-show="settings.display.blockTitle.visible()">{{ settings.display.blockTitle.text() }}</span>
-            <img id="iconCompleted" ng-show="settings.display.completionIcon.visible()" src="/content/images/student/flagCompleted.png" />
         </div>
         <div class="toolbar-button-group">
             <button id="timer-btn" class="toolbar-button btn-sticky btn-tray-master" button-name="timer" tabindex="0"


### PR DESCRIPTION
The "flag" image was set to be displayed in the toolbar just under ace accession number. The image is no longer used so all references have been removed.